### PR TITLE
correct dcrwallet/dcrstakepoold count check, allow empty smtphost configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 config.toml
 dcrstakepool
-.vendor/
+vendor/
 .vscode/
+.idea/
 controllers/config.go*
 testing/
 *.orig

--- a/config.go
+++ b/config.go
@@ -582,9 +582,9 @@ func loadConfig() (*config, []string, error) {
 	// Add default wallet port for the active network if there's no port specified
 	cfg.WalletHosts = normalizeAddresses(cfg.WalletHosts, activeNetParams.WalletRPCServerPort)
 
-	if len(cfg.WalletHosts) < 2 {
-		str := "%s: you must specify at least 2 wallethosts"
-		err := fmt.Errorf(str, funcName)
+	if len(cfg.WalletHosts) < cfg.MinServers {
+		str := "%s: you must specify at least %d wallethosts"
+		err := fmt.Errorf(str, funcName, cfg.MinServers)
 		fmt.Fprintln(os.Stderr, err)
 		return nil, nil, err
 	}
@@ -646,9 +646,9 @@ func loadConfig() (*config, []string, error) {
 	// no port specified
 	cfg.StakepooldHosts = normalizeAddresses(cfg.StakepooldHosts,
 		activeNetParams.StakepooldRPCServerPort)
-	if len(cfg.StakepooldHosts) < 2 {
-		str := "%s: you must specify at least 2 stakepooldhosts"
-		err := fmt.Errorf(str, funcName)
+	if len(cfg.StakepooldHosts) < cfg.MinServers {
+		str := "%s: you must specify at least %d stakepooldhosts"
+		err := fmt.Errorf(str, funcName, cfg.MinServers)
 		fmt.Fprintln(os.Stderr, err)
 		return nil, nil, err
 	}

--- a/server.go
+++ b/server.go
@@ -89,10 +89,13 @@ func runMain() error {
 		return fmt.Errorf("Failed to connect to stakepoold host: %v", err)
 	}
 
-	sender, err := email.NewSender(cfg.SMTPHost, cfg.SMTPUsername, cfg.SMTPPassword, cfg.SMTPFrom, cfg.UseSMTPS)
-	if err != nil {
-		application.Close()
-		return fmt.Errorf("Failed to initialize the smtp server: %v", err)
+	var sender email.Sender
+	if cfg.SMTPHost != "" {
+		sender, err = email.NewSender(cfg.SMTPHost, cfg.SMTPUsername, cfg.SMTPPassword, cfg.SMTPFrom, cfg.UseSMTPS)
+		if err != nil {
+			application.Close()
+			return fmt.Errorf("Failed to initialize the smtp server: %v", err)
+		}
 	}
 
 	controller, err := controllers.NewMainController(activeNetParams.Params,


### PR DESCRIPTION
- Use `config.MinServers` parameter to check the number of required dcrwallet and dcrstakepoold instances.
- Readme says `SMTPHost now defaults to an empty string so a voting service can be used for development or testing purposes without a configured mail server.`
This doesn't work currently, producing the error message instead: `Failed to initialize the smtp server: invalid smtpfrom address ""`. Support for empty `smpthost` config value is implemented in this PR.