### PR TITLE
Config corrections and improvements to vsp setup process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 config.toml
 dcrstakepool
-.vendor/
+vendor/
 .vscode/
+.idea/
 controllers/config.go*
 testing/
 *.orig

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Before running dcrstakepool, have the following ready:
 - Frontend server - for hosting and serving the http frontend and Rest API.
 - Backend server(s) - for hosting the voting wallet(s).
 - Decred binaries (dcrd, dcrwallet and dcrctl).
-[Build each binary from its source code](#Building binaries from source) or
+[Build each binary from its source code](#Building-binaries-from-source) or
 [download the latest release from here](https://github.com/decred/decred-binaries/releases), look under the **Assets** section of the latest release for download links.
   - The latest release binaries of dcrd, dcrwallet and dcrctl may not work with the current `dcrstakepool` source code.
 If you encounter rpc version mismatch errors using the latest release decred binaries,
-follow [these steps](#Building binaries from source) to build each binary from source instead of using the release binaries.
+follow [these steps](#Building-binaries-from-source) to build each binary from source instead of using the release binaries.
 - VSP binaries (dcrstakepool and stakepoold).
-No release versions available yet, [build both binaries from source code](#Building binaries from source).
+No release versions available yet, [build both binaries from source code](#Building-binaries-from-source).
 
 _**Important notes:**_
 - For testing purposes, one server may be used for both frontend and backend.
@@ -78,7 +78,7 @@ The minimum configuration required is described [here](https://docs.decred.org/a
 dcrctl --wallet getmasterpubkey default
 ```
 - Make a copy of your dcrwallet rpc username, password and rpc.cert file.
-These will be required when [setting up the frontend server](#Set up the frontend server).
+These will be required when [setting up the frontend server](#Set-up-the-frontend-server).
 
 #### Set up MySQL
 - Install MySQL.
@@ -99,13 +99,13 @@ MySQL> CREATE DATABASE stakepool;
 and copy the contents of [sample-stakepoold.conf](sample-stakepoold.conf) into the new file.
 - Edit the config file as appropriate.
 Following config values must be set:
-  - `coldwalletextpub` - gotten from [this setup step](#Set up a cold wallet for VSP fee collection)
-  - `dbpassword` - password set [during MySQL setup](#Set up MySQL)
+  - `coldwalletextpub` - gotten from [this setup step](#Set-up-a-cold-wallet-for-VSP-fee-collection)
+  - `dbpassword` - password set [during MySQL setup](#Set-up-MySQL)
   - `dcrduser`, `dcrdpass`, `walletuser`, `walletpassword` - dcrd/dcrwallet rpc auth values
-  configured while [setting up the voting wallet](#Set up the voting wallet)
+  configured while [setting up the voting wallet](#Set-up-the-voting-wallet)
 - Run `stakepoold`.
 - Make a copy of your stakepoold rpc.cert file.
-It will be required when [setting up the frontend server](#Set up the frontend server).
+It will be required when [setting up the frontend server](#Set-up-the-frontend-server).
 
 ### Set up the frontend server
 
@@ -136,24 +136,24 @@ Following config values must be set:
   Can use `openssl rand -hex 32` to generate one.
   - `cookiesecret` - Secret string used to encrypt session data.
   Can use `openssl rand -hex 32` to generate one.
-  - `dbpassword` - password set [during MySQL setup](#Set up MySQL)
+  - `dbpassword` - password set [during MySQL setup](#Set-up-MySQL)
   - `votingwalletextpub` - Extended public key used to generate ticketed addresses which are
   combined with a user address for 1-of-2 multisig.
-  Should have been copied [while setting up the voting wallet on the server](#Set up the voting wallet).
+  Should have been copied [while setting up the voting wallet on the server](#Set-up-the-voting-wallet).
   - `coldwalletextpub` - Extended public key used to generate fee payment addresses,
-  gotten from [this setup step](#Set up a cold wallet for VSP fee collection).
+  gotten from [this setup step](#Set-up-a-cold-wallet-for-VSP-fee-collection).
   - `poolfees` - Fees as a percentage. 7.5 = 7.5%.  Precision of 2, 7.99 = 7.99%.
-  Should match dcrwallet's configuration (refer to [the second bullet point here](#Set up the voting wallet)).
+  Should match dcrwallet's configuration (refer to [the second bullet point here](#Set-up-the-voting-wallet)).
   - `stakepooldhosts` - IP address for all backend servers, separated by comma.
   Important to enable access to the stakepoold port on each backend server.
   - `stakepooldcerts` - relative or absolute path to rpc cert files for all backend servers, separated by comma.
-  Each backend rpc cert file should have been copied [while setting up stakepoold on the server](#Set up and run stakepoold).
+  Each backend rpc cert file should have been copied [while setting up stakepoold on the server](#Set-up-and-run-stakepoold).
   - `wallethosts` - IP address for the dcrwallet daemons on all backend servers, separated by comma.
   Important to enable access to the dcrwallet port on each backend server.
   - `walletcerts` - relative or absolute path to rpc cert files for the dcrwallet daemons on all backend servers, separated by comma.
-  Each rpc cert file should have been copied [while setting up the voting wallet on the server](#Set up the voting wallet).
+  Each rpc cert file should have been copied [while setting up the voting wallet on the server](#Set-up-the-voting-wallet).
   - `walletusers`, `walletpasswords` - comma separated list of rpc username and password for the dcrwallet daemons on all backend servers.
-  These info should have been copied/noted down [while setting up the voting wallet on the server](#Set up the voting wallet).
+  These info should have been copied/noted down [while setting up the voting wallet on the server](#Set-up-the-voting-wallet).
 - If the `dcrstakepool` binary is not in the same directory as the [public](public) and [views](views) folders,
 you will need to change `publicpath` and `templatepath` from their relative paths to an absolute path in `dcrstakepool.conf`.
 - Run `dcrstakepool`.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ They can be built from a development machine and copied to each server.
 ## Running dcrstakepool
 
 ### Set up a cold wallet for VSP fee collection
-- - Configure `dcrd`, `dcrwallet` and `dcrctl`.
-  The minimum setup required is described [here](https://docs.decred.org/advanced/manual-cli-install/#minimum-configuration).
+- Configure `dcrd`, `dcrwallet` and `dcrctl`.
+The minimum configuration required is described [here](https://docs.decred.org/advanced/manual-cli-install/#minimum-configuration).
+Remember to include `testnet=1` in all 3 config files to use testnet.
 - Run `dcrd` and let it sync fully.
 - Run `dcrwallet --create` to create the fee collection wallet.
 - (Optional) Create a new account in the wallet for use in generating fee addresses:
@@ -57,7 +58,8 @@ Fees from UserId 1 will go to address 1, UserId 2 to address 2, and so on.
 dcrctl --wallet accountsyncaddressindex vspfees 0 10000
 ```
 - Get the master pubkey for the account you wish to use.
-This will be needed to configure dcrwallet and dcrstakepool (`coldwalletextpub`).
+This will be needed to configure the **dcrwallet** and **stakepoold** daemons on each backend server;
+and **dcrstakepool** (`coldwalletextpub`).
 ```bash
 dcrctl --wallet getmasterpubkey vspfees
 ```
@@ -68,16 +70,17 @@ Perform the following steps on each backend server, where voting will occur:
 #### Set up the voting wallet
 - Copy `dcrd`, `dcrwallet` and `dcrctl` to the backend server and configure them.
 The minimum configuration required is described [here](https://docs.decred.org/advanced/manual-cli-install/#minimum-configuration).
-- See [sample-dcrwallet.conf](sample-dcrwallet.conf) for other required `dcrwallet` configuration options.
+Remember to include `testnet=1` in all 3 config files to use testnet.
+- See [sample-dcrwallet.conf](sample-dcrwallet.conf) for other **REQUIRED** `dcrwallet` configuration options.
 - Run `dcrd` and let it sync fully.
 - Run `dcrwallet --create` to create the voting wallet.
 **IMPORTANT: Use the same seed for all voting wallets. Backup the seed for disaster recovery!** 
 - Start the `dcrwallet` daemon and unlock the wallet by providing your wallet's private passphrase: `dcrwallet --promptpass`
-- Get the master pubkey from the default account. This will be used for votingwalletextpub in dcrstakepool.conf:
+- Get the master pubkey from the default account. This will be used for setting `votingwalletextpub` in `dcrstakepool.conf`:
 ```bash
 dcrctl --wallet getmasterpubkey default
 ```
-- Make a copy of your dcrwallet rpc username, password and rpc.cert file.
+- Make a copy of your server IP address, dcrwallet rpc username, password and rpc.cert file.
 These will be required when [setting up the frontend server](#Set-up-the-frontend-server).
 
 #### Set up MySQL
@@ -100,6 +103,7 @@ and copy the contents of [sample-stakepoold.conf](sample-stakepoold.conf) into t
 - Edit the config file as appropriate.
 Following config values must be set:
   - `coldwalletextpub` - gotten from [this setup step](#Set-up-a-cold-wallet-for-VSP-fee-collection)
+  - `poolfees` - should be the same value set in `dcrwallet.conf`
   - `dbpassword` - password set [during MySQL setup](#Set-up-MySQL)
   - `dcrduser`, `dcrdpass`, `walletuser`, `walletpassword` - dcrd/dcrwallet rpc auth values
   configured while [setting up the voting wallet](#Set-up-the-voting-wallet)
@@ -154,6 +158,7 @@ Following config values must be set:
   Each rpc cert file should have been copied [while setting up the voting wallet on the server](#Set-up-the-voting-wallet).
   - `walletusers`, `walletpasswords` - comma separated list of rpc username and password for the dcrwallet daemons on all backend servers.
   These info should have been copied/noted down [while setting up the voting wallet on the server](#Set-up-the-voting-wallet).
+  - `minservers` (optional) - minimum number of stakepoold backend servers required for dcrstakepool to run. Default is 2.
 - If the `dcrstakepool` binary is not in the same directory as the [public](public) and [views](views) folders,
 you will need to change `publicpath` and `templatepath` from their relative paths to an absolute path in `dcrstakepool.conf`.
 - Run `dcrstakepool`.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,184 @@ vote on their behalf when the ticket is selected.
 - The architecture is subject to change in the future to lessen the dependence
   on dcrwallet and MySQL.
 
+## Getting ready to run dcrstakepool
+
+### Requirements
+Before running dcrstakepool, have the following ready:
+- Frontend server - for hosting and serving the http frontend and Rest API.
+- Backend server(s) - for hosting the voting wallet(s).
+- Decred binaries (dcrd, dcrwallet and dcrctl).
+[Build each binary from its source code](#Building binaries from source) or
+[download the latest release from here](https://github.com/decred/decred-binaries/releases), look under the **Assets** section of the latest release for download links.
+  - The latest release binaries of dcrd, dcrwallet and dcrctl may not work with the current `dcrstakepool` source code.
+If you encounter rpc version mismatch errors using the latest release decred binaries,
+follow [these steps](#Building binaries from source) to build each binary from source instead of using the release binaries.
+- VSP binaries (dcrstakepool and stakepoold).
+No release versions available yet, [build both binaries from source code](#Building binaries from source).
+
+_**Important notes:**_
+- For testing purposes, one server may be used for both frontend and backend.
+It is however recommended to use different physical servers for production.
+- The required decred and VSP binaries DO NOT need to be built on the server(s).
+They can be built from a development machine and copied to each server.
+
+## Running dcrstakepool
+
+### Set up a cold wallet for VSP fee collection
+- - Configure `dcrd`, `dcrwallet` and `dcrctl`.
+  The minimum setup required is described [here](https://docs.decred.org/advanced/manual-cli-install/#minimum-configuration).
+- Run `dcrd` and let it sync fully.
+- Run `dcrwallet --create` to create the fee collection wallet.
+- (Optional) Create a new account in the wallet for use in generating fee addresses:
+```bash
+dcrctl --wallet createnewaccount vspfees
+```
+- Mark 10000 addresses in use for the account so the wallet will recognize transactions to those addresses.
+Fees from UserId 1 will go to address 1, UserId 2 to address 2, and so on.
+```bash
+dcrctl --wallet accountsyncaddressindex vspfees 0 10000
+```
+- Get the master pubkey for the account you wish to use.
+This will be needed to configure dcrwallet and dcrstakepool (`coldwalletextpub`).
+```bash
+dcrctl --wallet getmasterpubkey vspfees
+```
+
+### Set up the backend server(s)
+Perform the following steps on each backend server, where voting will occur:
+
+#### Set up the voting wallet
+- Copy `dcrd`, `dcrwallet` and `dcrctl` to the backend server and configure them.
+The minimum configuration required is described [here](https://docs.decred.org/advanced/manual-cli-install/#minimum-configuration).
+- See [sample-dcrwallet.conf](sample-dcrwallet.conf) for other required `dcrwallet` configuration options.
+- Run `dcrd` and let it sync fully.
+- Run `dcrwallet --create` to create the voting wallet.
+**IMPORTANT: Use the same seed for all voting wallets. Backup the seed for disaster recovery!** 
+- Start the `dcrwallet` daemon and unlock the wallet by providing your wallet's private passphrase: `dcrwallet --promptpass`
+- Get the master pubkey from the default account. This will be used for votingwalletextpub in dcrstakepool.conf:
+```bash
+dcrctl --wallet getmasterpubkey default
+```
+- Make a copy of your dcrwallet rpc username, password and rpc.cert file.
+These will be required when [setting up the frontend server](#Set up the frontend server).
+
+#### Set up MySQL
+- Install MySQL.
+- Setup MySQL user credentials and create stakepool database:
+```bash
+$ mysql -u root -p password
+MySQL> CREATE USER 'stakepool'@'localhost' IDENTIFIED BY 'password';
+MySQL> GRANT ALL PRIVILEGES ON *.* TO 'stakepool'@'localhost' WITH GRANT OPTION;
+MySQL> FLUSH PRIVILEGES;
+MySQL> CREATE DATABASE stakepool;
+```
+
+#### Set up and run stakepoold
+- Copy the `stakepoold` binary to the backend server.
+- Run `stakepoold -h` to see the stakepoold config file location on your server.
+- Copy [sample-stakepoold.conf](sample-stakepoold.conf) to the location above.
+- Or create the config file at the config location gotten above
+and copy the contents of [sample-stakepoold.conf](sample-stakepoold.conf) into the new file.
+- Edit the config file as appropriate.
+Following config values must be set:
+  - `coldwalletextpub` - gotten from [this setup step](#Set up a cold wallet for VSP fee collection)
+  - `dbpassword` - password set [during MySQL setup](#Set up MySQL)
+  - `dcrduser`, `dcrdpass`, `walletuser`, `walletpassword` - dcrd/dcrwallet rpc auth values
+  configured while [setting up the voting wallet](#Set up the voting wallet)
+- Run `stakepoold`.
+- Make a copy of your stakepoold rpc.cert file.
+It will be required when [setting up the frontend server](#Set up the frontend server).
+
+### Set up the frontend server
+
+#### Set up MySQL
+- Install MySQL.
+- Setup MySQL user credentials and create stakepool database:
+```bash
+$ mysql -u root -p password
+MySQL> CREATE USER 'stakepool'@'localhost' IDENTIFIED BY 'password';
+MySQL> GRANT ALL PRIVILEGES ON *.* TO 'stakepool'@'localhost' WITH GRANT OPTION;
+MySQL> FLUSH PRIVILEGES;
+MySQL> CREATE DATABASE stakepool;
+```
+
+#### Set up and run dcrstakepool
+- Copy the `dcrstakepool` binary to the backend server.
+- Also copy the [public](public) and [views](views) folders to the server,
+preferably the same location as the `dcrstakepool` binary.
+This step is unnecessary if dcrstakepool source code exists on the server,
+even if the binary is in a different location from the source code.
+- Run `dcrstakepool -h` to see the dcrstakepool config file location on your server.
+- Copy [sample-dcrstakepool.conf](sample-dcrstakepool.conf) to the location above.
+- Or create the config file at the config location gotten above
+and copy the contents of [sample-dcrstakepool.conf](sample-dcrstakepool.conf) into the new file.
+- Edit the config file as appropriate.
+Following config values must be set:
+  - `apisecret` - Secret string used to encrypt API and to generate CSRF tokens.
+  Can use `openssl rand -hex 32` to generate one.
+  - `cookiesecret` - Secret string used to encrypt session data.
+  Can use `openssl rand -hex 32` to generate one.
+  - `dbpassword` - password set [during MySQL setup](#Set up MySQL)
+  - `votingwalletextpub` - Extended public key used to generate ticketed addresses which are
+  combined with a user address for 1-of-2 multisig.
+  Should have been copied [while setting up the voting wallet on the server](#Set up the voting wallet).
+  - `coldwalletextpub` - Extended public key used to generate fee payment addresses,
+  gotten from [this setup step](#Set up a cold wallet for VSP fee collection).
+  - `poolfees` - Fees as a percentage. 7.5 = 7.5%.  Precision of 2, 7.99 = 7.99%.
+  Should match dcrwallet's configuration (refer to [the second bullet point here](#Set up the voting wallet)).
+  - `stakepooldhosts` - IP address for all backend servers, separated by comma.
+  Important to enable access to the stakepoold port on each backend server.
+  - `stakepooldcerts` - relative or absolute path to rpc cert files for all backend servers, separated by comma.
+  Each backend rpc cert file should have been copied [while setting up stakepoold on the server](#Set up and run stakepoold).
+  - `wallethosts` - IP address for the dcrwallet daemons on all backend servers, separated by comma.
+  Important to enable access to the dcrwallet port on each backend server.
+  - `walletcerts` - relative or absolute path to rpc cert files for the dcrwallet daemons on all backend servers, separated by comma.
+  Each rpc cert file should have been copied [while setting up the voting wallet on the server](#Set up the voting wallet).
+  - `walletusers`, `walletpasswords` - comma separated list of rpc username and password for the dcrwallet daemons on all backend servers.
+  These info should have been copied/noted down [while setting up the voting wallet on the server](#Set up the voting wallet).
+- If the `dcrstakepool` binary is not in the same directory as the [public](public) and [views](views) folders,
+you will need to change `publicpath` and `templatepath` from their relative paths to an absolute path in `dcrstakepool.conf`.
+- Run `dcrstakepool`.
+- Rest API and VSP frontend should be ready for use.
+
+## Supplementary info
+
+### Building binaries from source
+_PS: This assumes that you have installed Go 1.11 or later and you have added `$GOPATH/bin` to your `PATH` environment variable.
+Please do so before proceeding if you haven't already.
+You can access the go installation guide [here](http://golang.org/doc/install)._
+
+#### Decred binaries from source
+The following bash code builds the dcrd and dcrctl binaries and places them in `$GOPATH/src/github.com/decred/dcrd`.
+Replace `go build` with `go install` to place the binaries in `$GOPATH/bin`.
+```bash
+git clone https://github.com/decred/dcrd $GOPATH/src/github.com/decred/dcrd
+cd $GOPATH/src/github.com/decred/dcrd
+GO111MODULE=on go build && go build ./cmd/dcrctl
+```
+
+The following bash code builds the dcrwallet binary and places it in `$GOPATH/src/github.com/decred/dcrd`.
+Replace `go build` with `go install` to place the binary in `$GOPATH/bin`.
+```bash
+git clone https://github.com/decred/dcrwallet $GOPATH/src/github.com/decred/dcrwallet
+cd $GOPATH/src/github.com/decred/dcrwallet
+go install
+```
+
+#### dcrstakepool binaries from source
+The following bash code builds the dcrstakepool binary and places it in `$GOPATH/src/github.com/decred/dcrstakepool`.
+Replace `go build` with `go install` to place the binary in `$GOPATH/bin`.
+```bash
+git clone https://github.com/decred/dcrstakepool $GOPATH/src/github.com/decred/dcrstakepool
+cd $GOPATH/src/github.com/decred/dcrstakepool
+GO111MODULE=on go build
+```
+
+### Nginx/web server config
+
+- Adapt sample-nginx.conf or setup a different web server in a proxy
+  configuration.
+
 ## Git Tip Release notes
 
 - The handling of tickets considered invalid because they pay too-low-of-a-fee
@@ -92,210 +270,6 @@ vote on their behalf when the ticket is selected.
 5) Announce maintenance complete after verifying functionality.  If possible,
    also announce that a new voting agenda is available and users must login
    to set their preferences for the new agenda.
-
-## Requirements
-
-- [Go](http://golang.org) 1.10.5 or newer (1.11 is recommended).
-- MySQL
-- Nginx or other web server to proxy to dcrstakepool
-
-## Installation
-
-### Build from Source
-
-Building or updating from source requires only an installation of Go
-([instructions](http://golang.org/doc/install)). It is recommended to add
-`$GOPATH/bin` to your `PATH` at this point.
-
-Clone the dcrstakepool repository into any folder and follow the instructions
-below for your version of Go.
-
-#### Building with Go 1.11
-
-Go 1.11 introduced native support for
-[modules](https://github.com/golang/go/wiki/Modules), a new dependency
-management approach, that obviates the need for third party tooling such as
-`dep`.
-
-Usage is simple, and nothing is required except Go 1.11. If building in a folder
-under `GOPATH`, it is necessary to explicitly build with modules enabled:
-
-    GO111MODULE=on go build
-
-If building outside of `GOPATH`, modules are automatically enabled, and `go
-build` is sufficient.
-
-The `go` tool will process the source code and automatically download
-dependencies. If the dependencies are configured correctly, there will be no
-modifications to the `go.mod` and `go.sum` files.
-
-#### Building with Go 1.10
-
-Module-enabled builds with Go 1.10 require the
-[vgo](https://github.com/golang/vgo) command. Follow the same procedures as if
-you were [using Go 1.11](#building-with-go-111), but replacing `go` with `vgo`.
-
-**NOTE:** The `dep` tool is no longer supported. If you must use Go 1.10,
-install and use `vgo`. If possible, upgrade to Go 1.11.
-
-### Components
-
-The frontend server (dcrstakepool) and the backend daemon (stakepoold) are built
-separately. Since module-enabled builds no longer require building under
-`$GOPATH`, the following instructions use the placeholder
-`{{YOUR_GO_MODULE_PATH}}` to refer to wherever you checkout your Go code.
-
-#### Frontend - dcrstakepool
-
-Build dcrstakepool and copy it to the web server.
-
-```bash
-$ cd {{YOUR_GO_MODULE_PATH}}/github.com/decred/dcrstakepool
-$ go build
-```
-
-#### Backend - stakepoold
-
-Build stakepoold and copy it to each voting wallet node.
-
-```bash
-$ cd {{YOUR_GO_MODULE_PATH}}/src/github.com/decred/dcrstakepool/backend/stakepoold
-$ go build
-```
-
-## Updating
-
-To update an existing source tree, pull the latest changes and install the
-matching dependencies:
-
-```bash
-$ cd $GOPATH/src/github.com/decred/dcrstakepool
-$ git pull
-$ dep ensure
-$ go build
-$ cd $GOPATH/src/github.com/decred/dcrstakepool/backend/stakepoold
-$ go build
-```
-
-## Setup
-
-### Pre-requisites
-
-These instructions assume you are familiar with dcrd/dcrwallet.
-
-- Create basic dcrd/dcrwallet/dcrctl config files with usernames, passwords,
-  rpclisten, and network set appropriately within them or run example commands
-  with additional flags as necessary.
-
-- Build/install dcrd and dcrwallet from latest master.
-
-- Run dcrd instances and let them fully sync.
-
-### Voting service fees/cold wallet
-
-- Setup a new wallet for receiving payment for voting service fees.  **This should
-  be completely separate from the voting service infrastructure.**
-
-```bash
-$ dcrwallet --create
-$ dcrwallet
-```
-
-- Get the master pubkey for the account you wish to use. This will be needed to
-  configure dcrwallet and dcrstakepool.
-
-```bash
-$ dcrctl --wallet createnewaccount teststakepoolfees
-$ dcrctl --wallet getmasterpubkey teststakepoolfees
-```
-
-- Mark 10000 addresses in use for the account so the wallet will recognize
-  transactions to those addresses. Fees from UserId 1 will go to address 1,
-  UserId 2 to address 2, and so on.
-
-```bash
-$ dcrctl --wallet accountsyncaddressindex teststakepoolfees 0 10000
-```
-
-### Voting service voting wallets
-
-- Create the wallets.  All wallets should have the same seed.  **Backup the seed
-  for disaster recovery!**
-
-```bash
-$ dcrwallet --create
-```
-
-- Start a properly configured dcrwallet and unlock it. See
-  sample-dcrwallet.conf.
-
-```bash
-$ dcrwallet
-```
-
-- Get the master pubkey from the default account.  This will be used for
-  votingwalletextpub in dcrstakepool.conf.
-
-```bash
-$ dcrctl --wallet getmasterpubkey default
-```
-
-### MySQL
-
-- Install, configure, and start MySQL
-- Add stakepool user and create the stakepool database
-
-```bash
-$ mysql -uroot -ppassword
-
-MySQL> CREATE USER 'stakepool'@'localhost' IDENTIFIED BY 'password';
-MySQL> GRANT ALL PRIVILEGES ON *.* TO 'stakepool'@'localhost' WITH GRANT OPTION;
-MySQL> FLUSH PRIVILEGES;
-MySQL> CREATE DATABASE stakepool;
-```
-
-### Nginx/web server
-
-- Adapt sample-nginx.conf or setup a different web server in a proxy
-  configuration.
-
-### stakepoold setup
-
-- Adapt sample-stakepoold.conf and run stakepoold.
-
-### dcrstakepool setup
-
-- Create the .dcrstakepool directory and copy dcrwallet certs to it:
-
-```bash
-$ mkdir ~/.dcrstakepool
-$ cd ~/.dcrstakepool
-$ scp walletserver1:~/.dcrwallet/rpc.cert wallet1.cert
-$ scp walletserver2:~/.dcrwallet/rpc.cert wallet2.cert
-$ scp walletserver1:~/.stakepoold/rpc.cert stakepoold1.cert
-$ scp walletserver2:~/.stakepoold/rpc.cert stakepoold2.cert
-```
-
-- Copy sample config and edit appropriately.
-
-```bash
-$ cp -p sample-dcrstakepool.conf dcrstakepool.conf
-```
-
-## Running
-
-The easiest way to run the stakepool code is to run it directly from the root of
-the source tree:
-
-```bash
-$ cd $GOPATH/src/github.com/decred/dcrstakepool
-$ go build
-$ ./dcrstakepool
-```
-
-If you wish to run dcrstakepool from a different directory you will need to
-change **publicpath** and **templatepath** from their relative paths to an
-absolute path.
 
 ## Development
 

--- a/backend/stakepoold/config.go
+++ b/backend/stakepoold/config.go
@@ -58,17 +58,17 @@ var runServiceCommand func(string) error
 //
 // See loadConfig for details on the configuration load process.
 type config struct {
-	HomeDir          string   `short:"A" long:"appdata" description:"Path to application home directory"`
-	ShowVersion      bool     `short:"V" long:"version" description:"Display version information and exit"`
-	ConfigFile       string   `short:"C" long:"configfile" description:"Path to configuration file"`
-	DataDir          string   `short:"b" long:"datadir" description:"Directory to store data"`
-	LogDir           string   `long:"logdir" description:"Directory to log output."`
-	TestNet          bool     `long:"testnet" description:"Use the test network"`
-	SimNet           bool     `long:"simnet" description:"Use the simulation test network"`
-	Profile          string   `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
-	CPUProfile       string   `long:"cpuprofile" description:"Write CPU profile to the specified file"`
-	MemProfile       string   `long:"memprofile" description:"Write mem profile to the specified file"`
-	DebugLevel       string   `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
+	HomeDir     string `short:"A" long:"appdata" description:"Path to application home directory"`
+	ShowVersion bool   `short:"V" long:"version" description:"Display version information and exit"`
+	ConfigFile  string `short:"C" long:"configfile" description:"Path to configuration file"`
+	DataDir     string `short:"b" long:"datadir" description:"Directory to store data"`
+	LogDir      string `long:"logdir" description:"Directory to log output."`
+	TestNet     bool   `long:"testnet" description:"Use the test network"`
+	SimNet      bool   `long:"simnet" description:"Use the simulation test network"`
+	Profile     string `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
+	CPUProfile  string `long:"cpuprofile" description:"Write CPU profile to the specified file"`
+	MemProfile  string `long:"memprofile" description:"Write mem profile to the specified file"`
+	DebugLevel  string `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 	// todo can `ColdWalletExtPub` and `PoolFees` be read from the connected dcrwallet instance via dcrwallet rpc instead?
 	// todo alternatively, can have dcrstakepool provide `ColdWalletExtPub` and `PoolFees` via stakepoold rpc
 	ColdWalletExtPub string   `long:"coldwalletextpub" description:"The extended public key for addresses to which voting service user fees are sent."`

--- a/backend/stakepoold/config.go
+++ b/backend/stakepoold/config.go
@@ -26,7 +26,6 @@ const (
 	defaultLogLevel       = "info"
 	defaultLogDirname     = "logs"
 	defaultLogFilename    = "stakepoold.log"
-	defaultPoolFees       = 5
 )
 
 var (
@@ -34,7 +33,7 @@ var (
 	defaultConfigFile  = filepath.Join(defaultHomeDir, defaultConfigFilename)
 	defaultDataDir     = filepath.Join(defaultHomeDir, defaultDataDirname)
 	defaultRPCKeyFile  = filepath.Join(defaultHomeDir, "rpc.key")
-	defaultRPCCertFile = filepath.Join(defaultHomeDir, "rpc.cert")
+	defaultRPCCertFile = filepath.Join(defaultHomeDir, "rpc.cert") // todo need similar default cert file locations for dcrd/dcrwallet
 	defaultLogDir      = filepath.Join(defaultHomeDir, defaultLogDirname)
 
 	defaultDBName = "stakepool"
@@ -62,7 +61,6 @@ type config struct {
 	MemProfile       string   `long:"memprofile" description:"Write mem profile to the specified file"`
 	DebugLevel       string   `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 	ColdWalletExtPub string   `long:"coldwalletextpub" description:"The extended public key for addresses to which voting service user fees are sent."`
-	PoolFees         float64  `long:"poolfees" description:"The per-ticket fees the user must send to the voting service with their tickets"`
 	DBHost           string   `long:"dbhost" description:"Hostname for database connection"`
 	DBUser           string   `long:"dbuser" description:"Username for database connection"`
 	DBPassword       string   `long:"dbpassword" description:"Password for database connection"`
@@ -262,7 +260,6 @@ func loadConfig() (*config, []string, error) {
 		DBPort:     defaultDBPort,
 		DBUser:     defaultDBUser,
 		LogDir:     defaultLogDir,
-		PoolFees:   defaultPoolFees,
 		RPCKey:     defaultRPCKeyFile,
 		RPCCert:    defaultRPCCertFile,
 	}
@@ -486,6 +483,7 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
+	// todo default to localhost
 	if len(cfg.DcrdHost) == 0 {
 		str := "%s: dcrdhost is not set in config"
 		err := fmt.Errorf(str, funcName)
@@ -493,6 +491,7 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
+	// todo default to dcrd appdata dir
 	if len(cfg.DcrdCert) == 0 {
 		str := "%s: dcrdcert is not set in config"
 		err := fmt.Errorf(str, funcName)
@@ -514,6 +513,7 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
+	// todo default to localhost
 	if len(cfg.WalletHost) == 0 {
 		str := "%s: wallethost is not set in config"
 		err := fmt.Errorf(str, funcName)
@@ -521,6 +521,7 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
+	// todo default to dcrwallet appdata dir
 	if len(cfg.WalletCert) == 0 {
 		str := "%s: walletcert is not set in config"
 		err := fmt.Errorf(str, funcName)

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/decred/dcrd/rpcclient/v3"
 	"github.com/decred/dcrstakepool/backend/stakepoold/rpc/rpcserver"
 	"github.com/decred/dcrstakepool/backend/stakepoold/userdata"
+	"github.com/decred/dcrwallet/wallet/v2/txrules"
 	"github.com/decred/dcrwallet/wallet/v2/udb"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -192,17 +193,17 @@ func runMain() error {
 		log.Infof("loaded prefs for %d users from MySQL", len(userVotingConfig))
 	}
 
-	// todo need similar validation when setting pool fees via rpc
-	//if !txrules.ValidPoolFeeRate(cfg.PoolFees) {
-	//	err = fmt.Errorf("poolfees '%v' is invalid", cfg.PoolFees)
-	//	log.Error(err)
-	//	return err
-	//}
+	if !txrules.ValidPoolFeeRate(cfg.PoolFees) {
+		err = fmt.Errorf("poolfees '%v' is invalid", cfg.PoolFees)
+		log.Error(err)
+		return err
+	}
 
 	ctx := &rpcserver.AppContext{
 		AddedLowFeeTicketsMSA:  addedLowFeeTicketsMSA,
 		DataPath:               cfg.DataDir,
 		FeeAddrs:               feeAddrs,
+		PoolFees:               cfg.PoolFees,
 		NewTicketsChan:         make(chan rpcserver.NewTicketsForBlock),
 		Params:                 activeNetParams.Params,
 		Quit:                   make(chan struct{}),

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -193,17 +193,17 @@ func runMain() error {
 		log.Infof("loaded prefs for %d users from MySQL", len(userVotingConfig))
 	}
 
-	if !txrules.ValidPoolFeeRate(cfg.PoolFees) {
-		err = fmt.Errorf("poolfees '%v' is invalid", cfg.PoolFees)
-		log.Error(err)
-		return err
-	}
+	// todo need similar validation when setting pool fees via rpc
+	//if !txrules.ValidPoolFeeRate(cfg.PoolFees) {
+	//	err = fmt.Errorf("poolfees '%v' is invalid", cfg.PoolFees)
+	//	log.Error(err)
+	//	return err
+	//}
 
 	ctx := &rpcserver.AppContext{
 		AddedLowFeeTicketsMSA:  addedLowFeeTicketsMSA,
 		DataPath:               cfg.DataDir,
 		FeeAddrs:               feeAddrs,
-		PoolFees:               cfg.PoolFees,
 		NewTicketsChan:         make(chan rpcserver.NewTicketsForBlock),
 		Params:                 activeNetParams.Params,
 		Quit:                   make(chan struct{}),

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -22,7 +22,6 @@ import (
 	"github.com/decred/dcrd/rpcclient/v3"
 	"github.com/decred/dcrstakepool/backend/stakepoold/rpc/rpcserver"
 	"github.com/decred/dcrstakepool/backend/stakepoold/userdata"
-	"github.com/decred/dcrwallet/wallet/v2/txrules"
 	"github.com/decred/dcrwallet/wallet/v2/udb"
 
 	_ "github.com/go-sql-driver/mysql"

--- a/config.go
+++ b/config.go
@@ -420,28 +420,22 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
-	// Multiple networks can't be selected simultaneously.
-	var numNets int
-
-	// Count number of network flags passed; assign active network params
-	// while we're at it
-	activeNetParams = &mainNetParams
-	if cfg.TestNet {
-		numNets++
-		activeNetParams = &testNet3Params
-	}
-	if cfg.SimNet {
-		numNets++
-		// Also disable dns seeding on the simulation test network.
-		activeNetParams = &simNetParams
-	}
-	if numNets > 1 {
+	if cfg.TestNet && cfg.SimNet {
 		str := "%s: The testnet and simnet params can't be " +
-			"used together -- choose one of the three"
+			"used together -- choose either of them"
 		err := fmt.Errorf(str, funcName)
 		fmt.Fprintln(os.Stderr, err)
 		fmt.Fprintln(os.Stderr, usageMessage)
 		return nil, nil, err
+	}
+
+	// assign active network params
+	activeNetParams = &mainNetParams
+	if cfg.TestNet {
+		activeNetParams = &testNet3Params
+	} else if cfg.SimNet {
+		// Also disable dns seeding on the simulation test network.
+		activeNetParams = &simNetParams
 	}
 
 	// Append the network type to the data directory so it is "namespaced"
@@ -509,29 +503,15 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
-	if len(cfg.ColdWalletExtPub) == 0 {
-		str := "%s: coldwalletextpub is not set in config"
-		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
-		return nil, nil, err
-	}
-
-	if len(cfg.AdminIPs) == 0 {
-		str := "%s: adminips is not set in config"
-		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
-		return nil, nil, err
-	}
-
-	if len(cfg.AdminUserIDs) == 0 {
-		str := "%s: adminuserids is not set in config"
-		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
-		return nil, nil, err
-	}
-
 	if len(cfg.VotingWalletExtPub) == 0 {
 		str := "%s: votingwalletextpub is not set in config"
+		err := fmt.Errorf(str, funcName)
+		fmt.Fprintln(os.Stderr, err)
+		return nil, nil, err
+	}
+
+	if len(cfg.ColdWalletExtPub) == 0 {
+		str := "%s: coldwalletextpub is not set in config"
 		err := fmt.Errorf(str, funcName)
 		fmt.Fprintln(os.Stderr, err)
 		return nil, nil, err

--- a/config.go
+++ b/config.go
@@ -78,11 +78,13 @@ type config struct {
 	DebugLevel         string   `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 	APISecret          string   `long:"apisecret" description:"Secret string used to encrypt API tokens."`
 	BaseURL            string   `long:"baseurl" description:"BaseURL to use when sending links via email"`
+	// todo: can `ColdWalletExtPub` and `PoolFees` be read from stakepoold via rpc?
 	ColdWalletExtPub   string   `long:"coldwalletextpub" description:"The extended public key for addresses to which voting service user fees are sent."`
 	ClosePool          bool     `long:"closepool" description:"Disable user registration actions (sign-ups and submitting addresses)"`
 	ClosePoolMsg       string   `long:"closepoolmsg" description:"Message to display when closepool is set."`
 	CookieSecret       string   `long:"cookiesecret" description:"Secret string used to encrypt session data."`
 	CookieSecure       bool     `long:"cookiesecure" description:"Set whether cookies can be sent in clear text or not."`
+	// todo: possible to use a single db instance on stakepoold and access via rpc?
 	DBHost             string   `long:"dbhost" description:"Hostname for database connection"`
 	DBUser             string   `long:"dbuser" description:"Username for database connection"`
 	DBPassword         string   `long:"dbpassword" description:"Password for database connection"`
@@ -101,10 +103,12 @@ type config struct {
 	UseSMTPS           bool     `long:"usesmtps" description:"Connect to the SMTP server using smtps."`
 	StakepooldHosts    []string `long:"stakepooldhosts" description:"Hostnames for stakepoold servers"`
 	StakepooldCerts    []string `long:"stakepooldcerts" description:"Certificate paths for stakepoold servers"`
+	// todo: should be possible to communicate to backend wallets via stakepoold rpc instead
 	WalletHosts        []string `long:"wallethosts" description:"Hostnames for wallet servers"`
 	WalletUsers        []string `long:"walletusers" description:"Usernames for wallet servers"`
 	WalletPasswords    []string `long:"walletpasswords" description:"Passwords for wallet servers"`
 	WalletCerts        []string `long:"walletcerts" description:"Certificate paths for wallet servers"`
+	// todo: `VotingWalletExtPub` can be read from the vsp backend dcrwallet via stakepoold rpc instead!
 	VotingWalletExtPub string   `long:"votingwalletextpub" description:"The extended public key of the default account of the voting wallet"`
 	AdminIPs           []string `long:"adminips" description:"Expected admin host"`
 	AdminUserIDs       []string `long:"adminuserids" description:"User IDs of users who are allowed to access administrative functions."`
@@ -624,6 +628,9 @@ func loadConfig() (*config, []string, error) {
 
 	// Add default stakepoold port for the active network if there's
 	// no port specified
+	// todo: for mainnet (production) deployment, should check that
+	// - cfg.MinServers is not less than 2 DIFFERENT servers
+	// - no stakepoold host IP resolves to the same machine used for dcrstakepool (localhost)
 	cfg.StakepooldHosts = normalizeAddresses(cfg.StakepooldHosts,
 		activeNetParams.StakepooldRPCServerPort)
 	if len(cfg.StakepooldHosts) < cfg.MinServers {

--- a/config.go
+++ b/config.go
@@ -582,9 +582,9 @@ func loadConfig() (*config, []string, error) {
 	// Add default wallet port for the active network if there's no port specified
 	cfg.WalletHosts = normalizeAddresses(cfg.WalletHosts, activeNetParams.WalletRPCServerPort)
 
-	if len(cfg.WalletHosts) < 2 {
-		str := "%s: you must specify at least 2 wallethosts"
-		err := fmt.Errorf(str, funcName)
+	if len(cfg.WalletHosts) < cfg.MinServers {
+		str := "%s: you must specify at least %d wallethosts"
+		err := fmt.Errorf(str, funcName, cfg.MinServers)
 		fmt.Fprintln(os.Stderr, err)
 		return nil, nil, err
 	}
@@ -646,9 +646,9 @@ func loadConfig() (*config, []string, error) {
 	// no port specified
 	cfg.StakepooldHosts = normalizeAddresses(cfg.StakepooldHosts,
 		activeNetParams.StakepooldRPCServerPort)
-	if len(cfg.StakepooldHosts) < 2 {
-		str := "%s: you must specify at least 2 stakepooldhosts"
-		err := fmt.Errorf(str, funcName)
+	if len(cfg.StakepooldHosts) < cfg.MinServers {
+		str := "%s: you must specify at least %d stakepooldhosts"
+		err := fmt.Errorf(str, funcName, cfg.MinServers)
 		fmt.Fprintln(os.Stderr, err)
 		return nil, nil, err
 	}

--- a/config.go
+++ b/config.go
@@ -65,49 +65,49 @@ var runServiceCommand func(string) error
 //
 // See loadConfig for details on the configuration load process.
 type config struct {
-	ShowVersion        bool     `short:"V" long:"version" description:"Display version information and exit"`
-	ConfigFile         string   `short:"C" long:"configfile" description:"Path to configuration file"`
-	DataDir            string   `short:"b" long:"datadir" description:"Directory to store data"`
-	LogDir             string   `long:"logdir" description:"Directory to log output."`
-	Listen             string   `long:"listen" description:"Listen for connections on the specified interface/port (default all interfaces port: 9113, testnet: 19113)"`
-	TestNet            bool     `long:"testnet" description:"Use the test network"`
-	SimNet             bool     `long:"simnet" description:"Use the simulation test network"`
-	Profile            string   `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
-	CPUProfile         string   `long:"cpuprofile" description:"Write CPU profile to the specified file"`
-	MemProfile         string   `long:"memprofile" description:"Write mem profile to the specified file"`
-	DebugLevel         string   `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
-	APISecret          string   `long:"apisecret" description:"Secret string used to encrypt API tokens."`
-	BaseURL            string   `long:"baseurl" description:"BaseURL to use when sending links via email"`
+	ShowVersion bool   `short:"V" long:"version" description:"Display version information and exit"`
+	ConfigFile  string `short:"C" long:"configfile" description:"Path to configuration file"`
+	DataDir     string `short:"b" long:"datadir" description:"Directory to store data"`
+	LogDir      string `long:"logdir" description:"Directory to log output."`
+	Listen      string `long:"listen" description:"Listen for connections on the specified interface/port (default all interfaces port: 9113, testnet: 19113)"`
+	TestNet     bool   `long:"testnet" description:"Use the test network"`
+	SimNet      bool   `long:"simnet" description:"Use the simulation test network"`
+	Profile     string `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
+	CPUProfile  string `long:"cpuprofile" description:"Write CPU profile to the specified file"`
+	MemProfile  string `long:"memprofile" description:"Write mem profile to the specified file"`
+	DebugLevel  string `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
+	APISecret   string `long:"apisecret" description:"Secret string used to encrypt API tokens."`
+	BaseURL     string `long:"baseurl" description:"BaseURL to use when sending links via email"`
 	// todo: can `ColdWalletExtPub` and `PoolFees` be read from stakepoold via rpc?
-	ColdWalletExtPub   string   `long:"coldwalletextpub" description:"The extended public key for addresses to which voting service user fees are sent."`
-	ClosePool          bool     `long:"closepool" description:"Disable user registration actions (sign-ups and submitting addresses)"`
-	ClosePoolMsg       string   `long:"closepoolmsg" description:"Message to display when closepool is set."`
-	CookieSecret       string   `long:"cookiesecret" description:"Secret string used to encrypt session data."`
-	CookieSecure       bool     `long:"cookiesecure" description:"Set whether cookies can be sent in clear text or not."`
+	ColdWalletExtPub string `long:"coldwalletextpub" description:"The extended public key for addresses to which voting service user fees are sent."`
+	ClosePool        bool   `long:"closepool" description:"Disable user registration actions (sign-ups and submitting addresses)"`
+	ClosePoolMsg     string `long:"closepoolmsg" description:"Message to display when closepool is set."`
+	CookieSecret     string `long:"cookiesecret" description:"Secret string used to encrypt session data."`
+	CookieSecure     bool   `long:"cookiesecure" description:"Set whether cookies can be sent in clear text or not."`
 	// todo: possible to use a single db instance on stakepoold and access via rpc?
-	DBHost             string   `long:"dbhost" description:"Hostname for database connection"`
-	DBUser             string   `long:"dbuser" description:"Username for database connection"`
-	DBPassword         string   `long:"dbpassword" description:"Password for database connection"`
-	DBPort             string   `long:"dbport" description:"Port for database connection"`
-	DBName             string   `long:"dbname" description:"Name of database"`
-	PublicPath         string   `long:"publicpath" description:"Path to the public folder which contains css/fonts/images/javascript."`
-	TemplatePath       string   `long:"templatepath" description:"Path to the views folder which contains html files."`
-	PoolEmail          string   `long:"poolemail" description:"Email address to for support inquiries"`
-	PoolFees           float64  `long:"poolfees" description:"The per-ticket fees the user must send to the pool with their tickets"`
-	PoolLink           string   `long:"poollink" description:"URL for support inquiries such as forum, IRC, etc"`
-	RealIPHeader       string   `long:"realipheader" description:"The name of an HTTP request header containing the actual remote client IP address, typically set by a reverse proxy. An empty string (default) indicates to use net/Request.RemodeAddr."`
-	SMTPFrom           string   `long:"smtpfrom" description:"From address to use on outbound mail"`
-	SMTPHost           string   `long:"smtphost" description:"SMTP hostname/ip and port, e.g. mail.example.com:25"`
-	SMTPUsername       string   `long:"smtpusername" description:"SMTP username for authentication if required"`
-	SMTPPassword       string   `long:"smtppassword" description:"SMTP password for authentication if required"`
-	UseSMTPS           bool     `long:"usesmtps" description:"Connect to the SMTP server using smtps."`
-	StakepooldHosts    []string `long:"stakepooldhosts" description:"Hostnames for stakepoold servers"`
-	StakepooldCerts    []string `long:"stakepooldcerts" description:"Certificate paths for stakepoold servers"`
+	DBHost          string   `long:"dbhost" description:"Hostname for database connection"`
+	DBUser          string   `long:"dbuser" description:"Username for database connection"`
+	DBPassword      string   `long:"dbpassword" description:"Password for database connection"`
+	DBPort          string   `long:"dbport" description:"Port for database connection"`
+	DBName          string   `long:"dbname" description:"Name of database"`
+	PublicPath      string   `long:"publicpath" description:"Path to the public folder which contains css/fonts/images/javascript."`
+	TemplatePath    string   `long:"templatepath" description:"Path to the views folder which contains html files."`
+	PoolEmail       string   `long:"poolemail" description:"Email address to for support inquiries"`
+	PoolFees        float64  `long:"poolfees" description:"The per-ticket fees the user must send to the pool with their tickets"`
+	PoolLink        string   `long:"poollink" description:"URL for support inquiries such as forum, IRC, etc"`
+	RealIPHeader    string   `long:"realipheader" description:"The name of an HTTP request header containing the actual remote client IP address, typically set by a reverse proxy. An empty string (default) indicates to use net/Request.RemodeAddr."`
+	SMTPFrom        string   `long:"smtpfrom" description:"From address to use on outbound mail"`
+	SMTPHost        string   `long:"smtphost" description:"SMTP hostname/ip and port, e.g. mail.example.com:25"`
+	SMTPUsername    string   `long:"smtpusername" description:"SMTP username for authentication if required"`
+	SMTPPassword    string   `long:"smtppassword" description:"SMTP password for authentication if required"`
+	UseSMTPS        bool     `long:"usesmtps" description:"Connect to the SMTP server using smtps."`
+	StakepooldHosts []string `long:"stakepooldhosts" description:"Hostnames for stakepoold servers"`
+	StakepooldCerts []string `long:"stakepooldcerts" description:"Certificate paths for stakepoold servers"`
 	// todo: should be possible to communicate to backend wallets via stakepoold rpc instead
-	WalletHosts        []string `long:"wallethosts" description:"Hostnames for wallet servers"`
-	WalletUsers        []string `long:"walletusers" description:"Usernames for wallet servers"`
-	WalletPasswords    []string `long:"walletpasswords" description:"Passwords for wallet servers"`
-	WalletCerts        []string `long:"walletcerts" description:"Certificate paths for wallet servers"`
+	WalletHosts     []string `long:"wallethosts" description:"Hostnames for wallet servers"`
+	WalletUsers     []string `long:"walletusers" description:"Usernames for wallet servers"`
+	WalletPasswords []string `long:"walletpasswords" description:"Passwords for wallet servers"`
+	WalletCerts     []string `long:"walletcerts" description:"Certificate paths for wallet servers"`
 	// todo: `VotingWalletExtPub` can be read from the vsp backend dcrwallet via stakepoold rpc instead!
 	VotingWalletExtPub string   `long:"votingwalletextpub" description:"The extended public key of the default account of the voting wallet"`
 	AdminIPs           []string `long:"adminips" description:"Expected admin host"`

--- a/sample-dcrstakepool.conf
+++ b/sample-dcrstakepool.conf
@@ -26,11 +26,9 @@ description=Your VSP description
 ;cookiesecure=true
 
 ; No default password so you need to specify one.
-; todo stakepoold db instance should suffice!
 ;dbpassword=
 
 ; Other database configuration with their default values, change as needed.
-; todo stakepoold db instance should suffice!
 ;dbhost=localhost
 ;dbport=3306
 ;dbname=stakepool
@@ -39,18 +37,15 @@ description=Your VSP description
 ; Specified extended public key is used to generate ticketed addresses
 ; which are combined with a user address for 1-of-2 multisig.
 ; Must be the voting wallet's masterpubkey for the default account.
-; todo this can be read from the vsp backend dcrwallet via stakepoold rpc instead!
 ;votingwalletextpub=xpub
 
 ; Specified extended public key is used to generate fee payment addresses
 ; which are presented to the user.
 ; Should match dcrwallet's stakepoolcoldextkey configuration (without :10000).
-; todo can this be read from the vsp backend dcrwallet via stakepoold rpc instead?
 ;coldwalletextpub=xpub
 
 ; Fees as a percentage. 7.5 = 7.5%.  Precision of 2, 7.99 = 7.99%.
 ; Should match dcrwallet's configuration.
-; todo can this be read from the vsp backend dcrwallet via stakepoold rpc instead?
 ;poolfees=7.5
 
 ; Stakepoold hosts, will use default stakepoold RPC port for network
@@ -62,15 +57,12 @@ description=Your VSP description
 
 ; Wallethosts, will use default dcrwallet RPC port for network
 ; if not specified.
-; todo stakepoold rpc connection should suffice!
 ;wallethosts=10.0.0.3,10.0.0.4,10.0.0.6
 
 ; Wallet RPC Cert.  Absolute path or relative name in ~/.dcrstakepool
-; todo stakepoold rpc connection should suffice!
 ;walletcerts=wallet1.cert,wallet2.cert,wallet3.cert
 
 ; Wallet RPC Usernames and passwords
-; todo stakepoold rpc connection should suffice!
 ;walletusers=user,user,user
 ;walletpasswords=pass,pass,pass
 

--- a/sample-dcrstakepool.conf
+++ b/sample-dcrstakepool.conf
@@ -1,8 +1,83 @@
+; Stay on testnet until everything is well tested.
+testnet=1
+
+; minservers lets you specify how many active wallet connections are required
+; for actions to occur (default 2)
+;minservers=2
+
+; The designated codename for this VSP. Customises the VSP logo in the top toolbar.
+; eg. Alpha, Bravo, etc
+designation=YourVSP
+
+; Operators own description of their VSP, up two to sentences.
+; Printed on the home screen under the VSP overview
+description=Your VSP description
+
+; Secret string used to encrypt API and to generate CSRF tokens.
+; Can use openssl rand -hex 32 to generate one.
+;apisecret=
+
+; Secret string used to encrypt session data.  Can use openssl rand -hex 32
+; to generate one.
+;cookiesecret=
+
+; Whether to set the secure flag on cookies.  If you have SSL/TLS setup then
+; you should change this to true.
+;cookiesecure=true
+
+; No default password so you need to specify one.
+; todo stakepoold db instance should suffice!
+;dbpassword=
+
+; Other database configuration with their default values, change as needed.
+; todo stakepoold db instance should suffice!
+;dbhost=localhost
+;dbport=3306
+;dbname=stakepool
+;dbuser=stakepool
+
+; Specified extended public key is used to generate ticketed addresses
+; which are combined with a user address for 1-of-2 multisig.
+; Must be the voting wallet's masterpubkey for the default account.
+; todo this can be read from the vsp backend dcrwallet via stakepoold rpc instead!
+;votingwalletextpub=xpub
+
+; Specified extended public key is used to generate fee payment addresses
+; which are presented to the user.
+; Should match dcrwallet's stakepoolcoldextkey configuration (without :10000).
+; todo can this be read from the vsp backend dcrwallet via stakepoold rpc instead?
+;coldwalletextpub=xpub
+
+; Fees as a percentage. 7.5 = 7.5%.  Precision of 2, 7.99 = 7.99%.
+; Should match dcrwallet's configuration.
+; todo can this be read from the vsp backend dcrwallet via stakepoold rpc instead?
+;poolfees=7.5
+
+; Stakepoold hosts, will use default stakepoold RPC port for network
+; if not specified.
+;stakepooldhosts=10.0.0.20,10.0.0.21
+
+; stakepoold RPC Cert.  Absolute path or relative name in ~/.dcrstakepool
+;stakepooldcerts=stakepoold1.cert,stakepoold2.cert
+
+; Wallethosts, will use default dcrwallet RPC port for network
+; if not specified.
+; todo stakepoold rpc connection should suffice!
+;wallethosts=10.0.0.3,10.0.0.4,10.0.0.6
+
+; Wallet RPC Cert.  Absolute path or relative name in ~/.dcrstakepool
+; todo stakepoold rpc connection should suffice!
+;walletcerts=wallet1.cert,wallet2.cert,wallet3.cert
+
+; Wallet RPC Usernames and passwords
+; todo stakepoold rpc connection should suffice!
+;walletusers=user,user,user
+;walletpasswords=pass,pass,pass
+
 ; Access to administrative pages like /status and /admintickets
 ; are restricted by both IP address and User ID.  Only if both filters pass
 ; will a user be able to access those functions.
-
-adminips=127.0.0.1
+;adminips=127.0.0.1
 ; Multiple values can be used and are separated by a comma.
 ;adminips=127.0.0.1,192.0.2.1,198.51.100.1
 
@@ -11,38 +86,15 @@ adminips=127.0.0.1
 ; Multiple values can be used and are separated by a comma.
 ;adminuserids=1,2,3
 
-; Secret string used to encrypt API and to generate CSRF tokens.
-; Can use openssl rand -hex 32 to generate one.
-;apisecret=
-
 ; baseurl to use when emailing verification links.
 ; Make sure to skip using a trailing slash.
-; baseurl=https://host.domain.tld
+;baseurl=https://host.domain.tld
 
 ; Disable new user signups.
 ;closepool=1
 
 ; If you want to specify a custom message, do so here.
 ;closepoolmsg=The voting service is temporarily closed to new signups.
-
-; Database configuration defaults to these, change as needed.
-;dbhost=localhost
-;dbport=3306
-;dbname=stakepool
-;dbuser=stakepool
-
-; No default password so you need to specify one.
-;dbpassword=
-
-; DEPRECATED: This option has no effect. Stakepoold is required.
-; enablestakepoold=true
-
-; Stakepoold hosts, will use default wallet RPC port for network
-; if not specified.
-; stakepooldhosts=10.0.0.20,10.0.0.21
-
-; stakepoold RPC Cert.  Absolute path or relative name in ~/.dcrstakepool
-; stakepooldcerts=stakepoold1.cert,stakepoold2.cert
 
 ; Specify a Go-style network listener.  Default is below.
 ;listen=:8000
@@ -56,15 +108,6 @@ adminips=127.0.0.1
 ; Support email and link show on the homepage.
 ;poolemail=admin@example.com
 ;poollink=https://example.com/
-
-; Specified extended public key is used to generate fee payment addresses
-; which are presented to the user.
-; Should match dcrwallet's stakepoolcoldextkey configuration (without :10000).
-;coldwalletextpub=xpub
-
-; Fees as a percentage. 7.5 = 7.5%.  Precision of 2, 7.99 = 7.99%.
-; Should match dcrwallet's configuration.
-;poolfees=7.5
 
 ; Mail server to use.  Default is an empty string which disables email-based
 ; features like email verification of new users, password resets, and email
@@ -82,25 +125,6 @@ adminips=127.0.0.1
 ; Connect to the SMTP server using smtps.
 ;usesmtps=false
 
-; Stay on testnet until everything is well tested.
-testnet=1
-
-; Specified extended public key is used to generate ticketed addresses
-; which are combined with a user address for 1-of-2 multisig.
-; Must be the voting wallet's masterpubkey for the default account.
-;votingwalletextpub=xpub
-
-; Wallethosts, will use default wallet RPC port for network
-; if not specified.
-;wallethosts=10.0.0.3,10.0.0.4,10.0.0.6
-
-; Wallet RPC Cert.  Absolute path or relative name in ~/.dcrstakepool
-;walletcerts=wallet1.cert,wallet2.cert,wallet3.cert
-
-; Wallet RPC Usernames and passwords
-;walletusers=user,user,user
-;walletpasswords=pass,pass,pass
-
 ; Debug logging level.
 ; Valid levels are {trace, debug, info, warn, error, critical}
 ; You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set
@@ -108,19 +132,7 @@ testnet=1
 ; list available subsystems.
 ; debuglevel=info
 
-; minservers lets you specify how many active wallet connections are required
-; for actions to occur (default 2)
-; minservers=2
-
 ; Various HTTP settings are in this section.
-
-; Secret string used to encrypt session data.  Can use openssl rand -hex 32
-; to generate one.
-;cookiesecret=
-
-; Whether to set the secure flag on cookies.  If you have SSL/TLS setup then
-; you should change this to true.
-;cookiesecure=true
 
 ; Path to the root folder/directory which contains CSS/fonts/images/javascript.
 ;publicpath=public
@@ -135,11 +147,3 @@ testnet=1
 
 ; Maximum number of voted tickets to show on tickets page.
 ;maxvotedtickets=1000
-
-; The designated codename for this VSP. Customises the VSP logo in the top toolbar.
-; eg. Alpha, Bravo, etc
-designation=YourVSP
-
-; Operators own description of their VSP, up two to sentences.
-; Printed on the home screen under the VSP overview
-description=Your VSP description

--- a/sample-stakepoold.conf
+++ b/sample-stakepoold.conf
@@ -2,9 +2,11 @@
 ; which are presented to the user.
 ; Should match dcrstakepool's coldwalletextpub configuration and dcrwallet's
 ; stakepoolcoldextkey configuration.
-; todo can this be read from the connected dcrwallet instance via rpc instead?
-; todo alternatively, read from frontend dcrstakepool!
 ;coldwalletextpub=xpub
+
+; Fees as a percentage. 7.5 = 7.5%.  Precision of 2, 7.99 = 7.99%.
+; Should match dcrstakepool and dcrwallet's configuration.
+;poolfees=7.5
 
 ; Stay on testnet until everything is well tested.  Ideally, you should run
 ; on testnet with lots of tickets as a benchmark to ensure votes are cast

--- a/sample-stakepoold.conf
+++ b/sample-stakepoold.conf
@@ -2,11 +2,9 @@
 ; which are presented to the user.
 ; Should match dcrstakepool's coldwalletextpub configuration and dcrwallet's
 ; stakepoolcoldextkey configuration.
+; todo can this be read from the connected dcrwallet instance via rpc instead?
+; todo alternatively, read from frontend dcrstakepool!
 ;coldwalletextpub=xpub
-
-; Fees as a percentage. 7.5 = 7.5%.  Precision of 2, 7.99 = 7.99%.
-; Should match dcrstakepool and dcrwallet's configuration.
-;poolfees=7.5
 
 ; Stay on testnet until everything is well tested.  Ideally, you should run
 ; on testnet with lots of tickets as a benchmark to ensure votes are cast
@@ -24,14 +22,16 @@ testnet=1
 
 ; You should have dcrd running on localhost so winning tickets notifications
 ; and vote relaying is fast.
-dcrdhost=127.0.0.1
-dcrdcert=../.dcrd/rpc.cert
+; dcrdhost defaults to localhost/127.0.0.1 while dcrdcert defaults to the dcrd appdata dir for your OS.
+;dcrdhost=127.0.0.1
+;dcrdcert=../.dcrd/rpc.cert
 ;dcrduser=user
 ;dcrdpassword=pass
 
 ; dcrwallet should be running on localhost so wallet RPCs are fast.
-wallethost=127.0.0.1
-walletcert=../.dcrwallet/rpc.cert
+; wallethost defaults to localhost/127.0.0.1 while walletcert defaults to the dcrwallet appdata dir for your OS.
+;wallethost=127.0.0.1
+;walletcert=../.dcrwallet/rpc.cert
 ;walletuser=user
 ;walletpassword=pass
 
@@ -44,4 +44,4 @@ walletcert=../.dcrwallet/rpc.cert
 ; You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set
 ; log level for individual subsystems.  Use stakepoold --debuglevel=show to list
 ; available subsystems.
-; debuglevel=info
+;debuglevel=info

--- a/server.go
+++ b/server.go
@@ -89,10 +89,13 @@ func runMain() error {
 		return fmt.Errorf("Failed to connect to stakepoold host: %v", err)
 	}
 
-	sender, err := email.NewSender(cfg.SMTPHost, cfg.SMTPUsername, cfg.SMTPPassword, cfg.SMTPFrom, cfg.UseSMTPS)
-	if err != nil {
-		application.Close()
-		return fmt.Errorf("Failed to initialize the smtp server: %v", err)
+	var sender email.Sender
+	if cfg.SMTPHost != "" {
+		sender, err = email.NewSender(cfg.SMTPHost, cfg.SMTPUsername, cfg.SMTPPassword, cfg.SMTPFrom, cfg.UseSMTPS)
+		if err != nil {
+			application.Close()
+			return fmt.Errorf("Failed to initialize the smtp server: %v", err)
+		}
 	}
 
 	controller, err := controllers.NewMainController(activeNetParams.Params,


### PR DESCRIPTION
- Use `config.MinServers` parameter to check the number of required dcrwallet and dcrstakepoold instances.
- Readme says `SMTPHost now defaults to an empty string so a voting service can be used for development or testing purposes without a configured mail server.`
This doesn't work currently, producing the error message instead: `Failed to initialize the smtp server: invalid smtpfrom address ""`. Support for empty `smpthost` config value is implemented in this PR.
- Remove config fields for values that can be gotten without an explicit configuration.
- Add todo comments on config parsing files for future config cleanup and simplification.
- Update readme to more accurately describe vsp setup steps