### PR TITLE
add /purchaseticket API endpoint

### DIFF
--- a/config.go
+++ b/config.go
@@ -67,50 +67,50 @@ var runServiceCommand func(string) error
 //
 // See loadConfig for details on the configuration load process.
 type config struct {
-	ShowVersion        bool    `short:"V" long:"version" description:"Display version information and exit"`
-	ConfigFile         string  `short:"C" long:"configfile" description:"Path to configuration file"`
-	DataDir            string  `short:"b" long:"datadir" description:"Directory to store data"`
-	LogDir             string  `long:"logdir" description:"Directory to log output."`
-	Listen             string  `long:"listen" description:"Listen for connections on the specified interface/port (default all interfaces port: 9113, testnet: 19113)"`
-	TestNet            bool    `long:"testnet" description:"Use the test network"`
-	SimNet             bool    `long:"simnet" description:"Use the simulation test network"`
-	Profile            string  `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
-	CPUProfile         string  `long:"cpuprofile" description:"Write CPU profile to the specified file"`
-	MemProfile         string  `long:"memprofile" description:"Write mem profile to the specified file"`
-	DebugLevel         string  `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
-	APISecret          string  `long:"apisecret" description:"Secret string used to encrypt API tokens."`
-	BaseURL            string  `long:"baseurl" description:"BaseURL to use when sending links via email"`
+	ShowVersion bool   `short:"V" long:"version" description:"Display version information and exit"`
+	ConfigFile  string `short:"C" long:"configfile" description:"Path to configuration file"`
+	DataDir     string `short:"b" long:"datadir" description:"Directory to store data"`
+	LogDir      string `long:"logdir" description:"Directory to log output."`
+	Listen      string `long:"listen" description:"Listen for connections on the specified interface/port (default all interfaces port: 9113, testnet: 19113)"`
+	TestNet     bool   `long:"testnet" description:"Use the test network"`
+	SimNet      bool   `long:"simnet" description:"Use the simulation test network"`
+	Profile     string `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
+	CPUProfile  string `long:"cpuprofile" description:"Write CPU profile to the specified file"`
+	MemProfile  string `long:"memprofile" description:"Write mem profile to the specified file"`
+	DebugLevel  string `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
+	APISecret   string `long:"apisecret" description:"Secret string used to encrypt API tokens."`
+	BaseURL     string `long:"baseurl" description:"BaseURL to use when sending links via email"`
 	// todo: can `ColdWalletExtPub` and `PoolFees` be read from stakepoold via rpc?
-	ColdWalletExtPub   string  `long:"coldwalletextpub" description:"The extended public key for addresses to which voting service user fees are sent."`
-	ClosePool          bool    `long:"closepool" description:"Disable user registration actions (sign-ups and submitting addresses)"`
-	ClosePoolMsg       string  `long:"closepoolmsg" description:"Message to display when closepool is set."`
-	CookieSecret       string  `long:"cookiesecret" description:"Secret string used to encrypt session data."`
-	CookieSecure       bool    `long:"cookiesecure" description:"Set whether cookies can be sent in clear text or not."`
-	DBHost             string  `long:"dbhost" description:"Hostname for database connection"`
-	DBUser             string  `long:"dbuser" description:"Username for database connection"`
-	DBPassword         string  `long:"dbpassword" description:"Password for database connection"`
-	DBPort             string  `long:"dbport" description:"Port for database connection"`
-	DBName             string  `long:"dbname" description:"Name of database"`
-	PublicPath         string  `long:"publicpath" description:"Path to the public folder which contains css/fonts/images/javascript."`
-	TemplatePath       string  `long:"templatepath" description:"Path to the views folder which contains html files."`
-	PoolEmail          string  `long:"poolemail" description:"Email address to for support inquiries"`
-	PoolFees           float64 `long:"poolfees" description:"The per-ticket fees the user must send to the pool with their tickets"`
-	PoolLink           string  `long:"poollink" description:"URL for support inquiries such as forum, IRC, etc"`
-	RealIPHeader       string  `long:"realipheader" description:"The name of an HTTP request header containing the actual remote client IP address, typically set by a reverse proxy. An empty string (default) indicates to use net/Request.RemodeAddr."`
-	SMTPFrom           string  `long:"smtpfrom" description:"From address to use on outbound mail"`
-	SMTPHost           string  `long:"smtphost" description:"SMTP hostname/ip and port, e.g. mail.example.com:25"`
-	SMTPUsername       string  `long:"smtpusername" description:"SMTP username for authentication if required"`
-	SMTPPassword       string  `long:"smtppassword" description:"SMTP password for authentication if required"`
-	UseSMTPS           bool    `long:"usesmtps" description:"Connect to the SMTP server using smtps."`
-	SMTPSkipVerify     bool    `long:"smtpskipverify" description:"Skip SMTP TLS cert verification. Will only skip if SMTPCert is empty"`
-	SMTPCert           string  `long:"smtpcert" description:"Path for the smtp certificate file"`
-	SystemCerts        *x509.CertPool
-	StakepooldHosts    []string `long:"stakepooldhosts" description:"Hostnames for stakepoold servers"`
-	StakepooldCerts    []string `long:"stakepooldcerts" description:"Certificate paths for stakepoold servers"`
-	WalletHosts        []string `long:"wallethosts" description:"Deprecated: dcrstakepool no longer connects to dcrwallet"`
-	WalletUsers        []string `long:"walletusers" description:"Deprecated: dcrstakepool no longer connects to dcrwallet"`
-	WalletPasswords    []string `long:"walletpasswords" description:"Deprecated: dcrstakepool no longer connects to dcrwallet"`
-	WalletCerts        []string `long:"walletcerts" description:"Deprecated: dcrstakepool no longer connects to dcrwallet"`
+	ColdWalletExtPub string  `long:"coldwalletextpub" description:"The extended public key for addresses to which voting service user fees are sent."`
+	ClosePool        bool    `long:"closepool" description:"Disable user registration actions (sign-ups and submitting addresses)"`
+	ClosePoolMsg     string  `long:"closepoolmsg" description:"Message to display when closepool is set."`
+	CookieSecret     string  `long:"cookiesecret" description:"Secret string used to encrypt session data."`
+	CookieSecure     bool    `long:"cookiesecure" description:"Set whether cookies can be sent in clear text or not."`
+	DBHost           string  `long:"dbhost" description:"Hostname for database connection"`
+	DBUser           string  `long:"dbuser" description:"Username for database connection"`
+	DBPassword       string  `long:"dbpassword" description:"Password for database connection"`
+	DBPort           string  `long:"dbport" description:"Port for database connection"`
+	DBName           string  `long:"dbname" description:"Name of database"`
+	PublicPath       string  `long:"publicpath" description:"Path to the public folder which contains css/fonts/images/javascript."`
+	TemplatePath     string  `long:"templatepath" description:"Path to the views folder which contains html files."`
+	PoolEmail        string  `long:"poolemail" description:"Email address to for support inquiries"`
+	PoolFees         float64 `long:"poolfees" description:"The per-ticket fees the user must send to the pool with their tickets"`
+	PoolLink         string  `long:"poollink" description:"URL for support inquiries such as forum, IRC, etc"`
+	RealIPHeader     string  `long:"realipheader" description:"The name of an HTTP request header containing the actual remote client IP address, typically set by a reverse proxy. An empty string (default) indicates to use net/Request.RemodeAddr."`
+	SMTPFrom         string  `long:"smtpfrom" description:"From address to use on outbound mail"`
+	SMTPHost         string  `long:"smtphost" description:"SMTP hostname/ip and port, e.g. mail.example.com:25"`
+	SMTPUsername     string  `long:"smtpusername" description:"SMTP username for authentication if required"`
+	SMTPPassword     string  `long:"smtppassword" description:"SMTP password for authentication if required"`
+	UseSMTPS         bool    `long:"usesmtps" description:"Connect to the SMTP server using smtps."`
+	SMTPSkipVerify   bool    `long:"smtpskipverify" description:"Skip SMTP TLS cert verification. Will only skip if SMTPCert is empty"`
+	SMTPCert         string  `long:"smtpcert" description:"Path for the smtp certificate file"`
+	SystemCerts      *x509.CertPool
+	StakepooldHosts  []string `long:"stakepooldhosts" description:"Hostnames for stakepoold servers"`
+	StakepooldCerts  []string `long:"stakepooldcerts" description:"Certificate paths for stakepoold servers"`
+	WalletHosts      []string `long:"wallethosts" description:"Deprecated: dcrstakepool no longer connects to dcrwallet"`
+	WalletUsers      []string `long:"walletusers" description:"Deprecated: dcrstakepool no longer connects to dcrwallet"`
+	WalletPasswords  []string `long:"walletpasswords" description:"Deprecated: dcrstakepool no longer connects to dcrwallet"`
+	WalletCerts      []string `long:"walletcerts" description:"Deprecated: dcrstakepool no longer connects to dcrwallet"`
 	// todo: `VotingWalletExtPub` can be read from the vsp backend dcrwallet via stakepoold rpc instead!
 	VotingWalletExtPub string   `long:"votingwalletextpub" description:"The extended public key of the default account of the voting wallet"`
 	AdminIPs           []string `long:"adminips" description:"Expected admin host"`

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -281,7 +281,7 @@ func (controller *MainController) API(c web.C, r *http.Request) *system.APIRespo
 		case "address":
 			_, code, response, err = controller.APIAddress(c, r)
 		case "purchaseticket":
-			_, code, response, err = controller.APIPurchaseTicket(c, r)
+			data, code, response, err = controller.APIPurchaseTicket(c, r)
 		case "voting":
 			_, code, response, err = controller.APIVoting(c, r)
 		default:

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -406,16 +406,13 @@ func (controller *MainController) APIPurchaseTicket(c web.C, r *http.Request) (*
 		return purchaseInfo, codes.OK, "APIPurchaseTicket: purchaseinfo retrieved for existing userPubKeyAddr", nil
 	}
 
-	//token := models.NewUserToken()
 	user = &models.User{
 		Username:        userPubKeyAddr,
 		Email:           userPubKeyAddr,
-		//EmailToken:      token.String(),
 		EmailVerified:   0,
 		VoteBits:        1,
 		VoteBitsVersion: int64(controller.voteVersion),
 	}
-	//user.HashPassword(password)
 
 	remoteIP := getClientIP(r, controller.realIPHeader)
 	log.Infof("APIPurchaseTicket POST from %v, created new user account %v. Inserting.", remoteIP, user.Email)

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -362,7 +362,7 @@ func (controller *MainController) APIAddress(c web.C, r *http.Request) ([]string
 		return nil, codes.Unavailable, "system error", errors.New("unable to process wallet commands")
 	}
 
-	userFeeAddr, err := controller.FeeAddressForUserID(userId)
+	userFeeAddr, err := controller.FeeAddressForUserID(int(user.Id))
 	if err != nil {
 		log.Warnf("unexpected error deriving pool addr: %s", err.Error())
 		return nil, codes.Unavailable, "system error", errors.New("unable to process wallet commands")
@@ -386,8 +386,7 @@ func (controller *MainController) APIAddress(c web.C, r *http.Request) ([]string
 func (controller *MainController) APIPurchaseTicket(c web.C, r *http.Request) (*poolapi.PurchaseInfo, codes.Code, string, error) {
 	userPubKeyAddr := r.FormValue("UserPubKeyAddr")
 
-	u, err := validateUserPubKeyAddr(userPubKeyAddr)
-	if err != nil {
+	if _, err := validateUserPubKeyAddr(userPubKeyAddr); err != nil {
 		return nil, codes.InvalidArgument, "address error", err
 	}
 
@@ -417,7 +416,7 @@ func (controller *MainController) APIPurchaseTicket(c web.C, r *http.Request) (*
 	remoteIP := getClientIP(r, controller.realIPHeader)
 	log.Infof("APIPurchaseTicket POST from %v, created new user account %v. Inserting.", remoteIP, user.Email)
 
-	err = models.InsertUser(dbMap, user)
+	err := models.InsertUser(dbMap, user)
 	if err != nil {
 		log.Errorf("Error while creating new user account for ticket purchase: %v", err)
 		return nil, codes.Unavailable, "system error", errors.New("unable to setup db entry for purchase")
@@ -428,7 +427,7 @@ func (controller *MainController) APIPurchaseTicket(c web.C, r *http.Request) (*
 	userId := int(user.Id)
 
 	// Get the ticket address for this user
-	pooladdress, err := controller.TicketAddressForUserID(userId)
+	pooladdress, err := controller.TicketAddressForUserID(int(user.Id))
 	if err != nil {
 		log.Errorf("unable to derive ticket address: %v", err)
 		return nil, codes.Unavailable, "system error", errors.New("unable to process wallet commands")
@@ -447,29 +446,22 @@ func (controller *MainController) APIPurchaseTicket(c web.C, r *http.Request) (*
 
 	poolPubKeyAddr := poolValidateAddress.PubKeyAddr
 
-	p, err := dcrutil.DecodeAddress(poolPubKeyAddr)
-	if err != nil {
-		controller.handlePotentialFatalError("DecodeAddress poolPubKeyAddr", err)
+	if _, err = dcrutil.DecodeAddress(poolPubKeyAddr); err != nil {
 		return nil, codes.Unavailable, "system error", errors.New("unable to process wallet commands")
 	}
 
-	if controller.RPCIsStopped() {
-		return nil, codes.Unavailable, "system error", errors.New("unable to process wallet commands")
-	}
-	createMultiSig, err := controller.rpcServers.CreateMultisig(1, []dcrutil.Address{p, u})
+	createMultiSig, err := controller.StakepooldServers.CreateMultisig([]string{poolPubKeyAddr, userPubKeyAddr})
 	if err != nil {
-		controller.handlePotentialFatalError("CreateMultisig", err)
 		return nil, codes.Unavailable, "system error", errors.New("unable to process wallet commands")
 	}
 
-	// Serialize the RedeemScript (hex string -> []byte)
+	// Serialize the redeem script (hex string -> []byte)
 	serializedScript, err := hex.DecodeString(createMultiSig.RedeemScript)
 	if err != nil {
-		controller.handlePotentialFatalError("CreateMultisig DecodeString", err)
 		return nil, codes.Unavailable, "system error", errors.New("unable to process wallet commands")
 	}
 
-	// Import the RedeemScript
+	// Import the redeem script
 	var importedHeight int64
 	importedHeight, err = controller.StakepooldServers.ImportScript(serializedScript)
 	if err != nil {

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -498,10 +498,10 @@ func (controller *MainController) APIPurchaseTicket(c web.C, r *http.Request) (*
 	}
 
 	purchaseInfo := &poolapi.PurchaseInfo{
-		PoolAddress:   user.UserFeeAddr,
+		PoolAddress:   userFeeAddr.EncodeAddress(),
 		PoolFees:      controller.poolFees,
-		Script:        user.MultiSigScript,
-		TicketAddress: user.MultiSigAddress,
+		Script:        createMultiSig.RedeemScript,
+		TicketAddress: createMultiSig.Address,
 		VoteBits:      uint16(user.VoteBits),
 	}
 	return purchaseInfo, codes.OK, "APIPurchaseTicket: purchaseinfo generated for userPubKeyAddr", nil

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -362,7 +362,7 @@ func (controller *MainController) APIAddress(c web.C, r *http.Request) ([]string
 		return nil, codes.Unavailable, "system error", errors.New("unable to process wallet commands")
 	}
 
-	userFeeAddr, err := controller.FeeAddressForUserID(int(user.Id))
+	userFeeAddr, err := controller.FeeAddressForUserID(userId)
 	if err != nil {
 		log.Warnf("unexpected error deriving pool addr: %s", err.Error())
 		return nil, codes.Unavailable, "system error", errors.New("unable to process wallet commands")
@@ -372,7 +372,7 @@ func (controller *MainController) APIAddress(c web.C, r *http.Request) ([]string
 		createMultiSig.RedeemScript, poolPubKeyAddr, userPubKeyAddr,
 		userFeeAddr.EncodeAddress(), importedHeight)
 
-	log.Infof("successfully create multisigaddress for user %d", c.Env["APIUserID"])
+	log.Infof("successfully create multisigaddress for user %d", int(user.Id))
 
 	err = controller.StakepooldUpdateUsers(dbMap)
 	if err != nil {
@@ -425,10 +425,10 @@ func (controller *MainController) APIPurchaseTicket(c web.C, r *http.Request) (*
 
 	// load saved user info from db to get the user id
 	user = models.GetUserByEmail(dbMap, userPubKeyAddr)
-	userId := user.Id
+	userId := int(user.Id)
 
 	// Get the ticket address for this user
-	pooladdress, err := controller.TicketAddressForUserID(int(userId))
+	pooladdress, err := controller.TicketAddressForUserID(userId)
 	if err != nil {
 		log.Errorf("unable to derive ticket address: %v", err)
 		return nil, codes.Unavailable, "system error", errors.New("unable to process wallet commands")
@@ -487,7 +487,7 @@ func (controller *MainController) APIPurchaseTicket(c web.C, r *http.Request) (*
 		createMultiSig.RedeemScript, poolPubKeyAddr, userPubKeyAddr,
 		userFeeAddr.EncodeAddress(), importedHeight)
 
-	log.Infof("successfully create multisigaddress for user %d", c.Env["APIUserID"])
+	log.Infof("successfully create multisigaddress for user %d", userId)
 
 	err = controller.StakepooldUpdateUsers(dbMap)
 	if err != nil {


### PR DESCRIPTION
Ticket purchase feature without user signup/login can be accessed by making a POST request to `api/{version}/purchaseticket` where version can be `v1` or `v2`, passing `UserPubKeyAddr` in post body.

A `pubkeyaddr` can be generated by executing the following dcrctl commands against dcrwallet.
First, create a new wallet address with getnewaddress. Then, call validateaddress <yourAddress> and retrieve the address listed in the pubkeyaddr field of the response. The pubkeyaddr starts with Tk.

The following is an example:
```
$ dcrctl --testnet --wallet getnewaddress
TsExampleAddr1For2Demo3PurposesOnly
$ dcrctl --testnet --wallet validateaddress TsExampleAddr1For2Demo3PurposesOnly
{
  "isvalid": true,
  "address": "TsExampleAddr1For2Demo3PurposesOnly",
  "ismine": true,
  "pubkeyaddr": "TkExample0Addr1For2Demo4Purposes5Only6Do7Not8Use9Pls0",
  "pubkey": "022801337beefc0ffee1dab8d4ffa898a782466c9a1fc00ca8863de5438dc07dcc",
  "iscompressed": true,
  "account": "default"
}
```

Calling the new endpoint with a valid pubkeyaddr returns the following (sample) data:
```
{
    "status": "success",
    "code": 0,
    "message": "APIPurchaseTicket: purchaseinfo retrieved for existing userPubKeyAddr",
    "data": {
        "PoolAddress": "TsoWCv4btvs2276yZ9qQkNL1xv5EbrBLjAJ",
        "PoolFees": 7.5,
        "Script": "512102ffbb68c445608d24239c4f1435cea18a00a652d5296481123bbc40546f01415521038d980deefd1d7bee8e195204b2e00f87904ca992bf7995bca56e928c8fefc8b552ae",
        "TicketAddress": "TcZJ5jMFBbekWAueyAmhyb5SjUM5kw5wbdU",
        "VoteBits": 1,
        "VoteBitsVersion": 0
    }
}
```

Complete the ticket purchase using the data above:
- Import the redeem script:
```
$ dcrctl --testnet --wallet importscript 512102ffbb68c445608d24239c4f1435cea18a00a652d5296481123bbc40546f01415521038d980deefd1d7bee8e195204b2e00f87904ca992bf7995bca56e928c8fefc8b552ae
```

- Purchase the ticket using the ticket address, fee address and fee percentage values. The dcrctl command usage is `purchaseticket "fromaccount" spendlimit (minconf=1 "ticketaddress" numtickets "pooladdress" poolfees expiry "comment" ticketfee)` ([see the doc for details](https://docs.decred.org/wallets/cli/dcrwallet-tickets/#ticket-purchasing))
```
$ dcrctl --testnet --wallet purchaseticket "default" 100 1 TcZJ5jMFBbekWAueyAmhyb5SjUM5kw5wbdU 1 TsoWCv4btvs2276yZ9qQkNL1xv5EbrBLjAJ 7.5
```
